### PR TITLE
APP-15366 - Parse network interfaces to select only unique macAddresses

### DIFF
--- a/src/steps/converters.test.ts
+++ b/src/steps/converters.test.ts
@@ -1,5 +1,9 @@
 import { SentinelOneAgent, SentinelOneGroup } from '../client';
-import { createAgentEntity, createGroupEntity } from './converters';
+import {
+  createAgentEntity,
+  createGroupEntity,
+  getMacAddresses,
+} from './converters';
 
 test('createAgentEntity', () => {
   const agent: SentinelOneAgent = {
@@ -355,5 +359,84 @@ test('createGroupEntity', () => {
     totalAgents: 0,
     type: 'static',
     updatedAt: 1519706966257,
+  });
+});
+
+describe('getMacAddresses', () => {
+  it('should return an empty array if there are no network interfaces', () => {
+    const result = getMacAddresses([]);
+    expect(result).toEqual([]);
+  });
+
+  it('should return only public MAC addresses', () => {
+    const networkInterfaces: SentinelOneAgent['networkInterfaces'] = [
+      {
+        physical: '00:00:00:00:00:01',
+        inet: ['192.168.0.1'],
+      },
+      {
+        physical: '00:00:00:00:00:02',
+        inet: ['8.8.8.8'],
+      },
+    ] as SentinelOneAgent['networkInterfaces'];
+    const result = getMacAddresses(networkInterfaces);
+    expect(result).toEqual(['00:00:00:00:00:02']);
+  });
+
+  it('should filter out the default MAC address 00:00:00:00:00:00', () => {
+    const networkInterfaces: SentinelOneAgent['networkInterfaces'] = [
+      {
+        physical: '00:00:00:00:00:00',
+        inet: ['8.8.8.8'],
+      },
+    ] as SentinelOneAgent['networkInterfaces'];
+    const result = getMacAddresses(networkInterfaces);
+    expect(result).toEqual([]);
+  });
+
+  it('should include MAC addresses associated with public IPv6 addresses', () => {
+    const networkInterfaces: SentinelOneAgent['networkInterfaces'] = [
+      {
+        physical: '00:00:00:00:00:03',
+        inet6: ['2001:0db8:85a3:0000:0000:8a2e:0370:7334'],
+      },
+    ] as SentinelOneAgent['networkInterfaces'];
+    const result = getMacAddresses(networkInterfaces);
+    expect(result).toEqual(['00:00:00:00:00:03']);
+  });
+
+  it('should include MAC addresses with gateway IPs and gateway MAC addresses', () => {
+    const networkInterfaces: SentinelOneAgent['networkInterfaces'] = [
+      {
+        physical: '00:00:00:00:00:04',
+        inet: ['8.8.8.8'],
+        gatewayIp: '192.168.1.1',
+        gatewayMacAddress: '00:00:00:00:00:05',
+      },
+    ] as SentinelOneAgent['networkInterfaces'];
+    const result = getMacAddresses(networkInterfaces);
+    expect(result).toEqual(['00:00:00:00:00:04', '00:00:00:00:00:05']);
+  });
+
+  it('should not include MAC addresses associated with private IPv4 addresses', () => {
+    const networkInterfaces: SentinelOneAgent['networkInterfaces'] = [
+      {
+        physical: '00:00:00:00:00:06',
+        inet: ['10.0.0.1'],
+      },
+    ] as SentinelOneAgent['networkInterfaces'];
+    const result = getMacAddresses(networkInterfaces);
+    expect(result).toEqual([]);
+  });
+
+  it('should not include MAC addresses associated with private IPv6 addresses', () => {
+    const networkInterfaces: SentinelOneAgent['networkInterfaces'] = [
+      {
+        physical: '00:00:00:00:00:07',
+        inet6: ['fe80::1'],
+      },
+    ] as SentinelOneAgent['networkInterfaces'];
+    const result = getMacAddresses(networkInterfaces);
+    expect(result).toEqual([]);
   });
 });

--- a/src/steps/converters.test.ts
+++ b/src/steps/converters.test.ts
@@ -191,7 +191,7 @@ test('createAgentEntity with a gatewayIp networkInterface', () => {
       },
       {
         gatewayIp: 'something',
-        gatewayMacAddress: undefined,
+        gatewayMacAddress: '00:25:96:FF:FE:12:34:57',
         id: '1646418461658622399',
         inet: ['127.0.0.1'],
         inet6: [],
@@ -312,7 +312,7 @@ test('createAgentEntity with a gatewayIp networkInterface', () => {
     totalMemory: 8192,
     updatedAt: 1519706966257,
     uuid: 'ff819e70af13be381993075eb0ce5f2f6de05be2',
-    macAddress: ['11:25:96:FF:FE:12:34:56'],
+    macAddress: ['00:25:96:FF:FE:12:34:56', '00:25:96:FF:FE:12:34:57'],
     serial: 'dummy',
   });
 });

--- a/src/steps/converters.ts
+++ b/src/steps/converters.ts
@@ -182,16 +182,16 @@ export function getMacAddresses(
     const hasPublicIp =
       (ni.inet?.length && ni.inet.some(isPublicIp)) ||
       (ni.inet6?.length && ni.inet6.some(isPublicIp));
-    if (hasPublicIp) {
+    if (hasPublicIp && ni.physical !== "00:00:00:00:00:00") {
       publicMacAddresses.add(ni.physical);
     }
 
     // When selecting macAddresses, prefer networkInterfaces with a gatewayIp as they are more likely to have
     // had their physical macAddress given to them by a central authority rather than being purely virtual.
-    if (ni.gatewayIp && ni.gatewayMacAddress) {
+    if (ni.gatewayIp && ni.gatewayMacAddress && ni.gatewayMacAddress !== "00:00:00:00:00:00") {
       publicMacAddresses.add(ni.gatewayMacAddress);
     }
   });
 
-  return [...publicMacAddresses].filter((m) => m !== '00:00:00:00:00:00');
+  return [...publicMacAddresses]
 }

--- a/src/steps/converters.ts
+++ b/src/steps/converters.ts
@@ -155,25 +155,19 @@ export function createAgentEntity(
 export function getMacAddresses(
   networkInterfaces: SentinelOneAgent['networkInterfaces'],
 ): string[] {
-  const isPublicIp = (ip: string): boolean => {
-    const privateIp10Regex = /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/; // Matches 10.x.x.x
-    const privateIp172Regex = /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/; // Matches 172.16.x.x to 172.31.x.x
-    const privateIp192Regex = /^192\.168\.\d{1,3}\.\d{1,3}$/; // Matches 192.168.x.x
-    const apipaRegex = /^169\.254\.\d{1,3}\.\d{1,3}$/; // Matches 169.254.x.x (APIPA)
-    const privateIpv6Regex = /^(fc00::|fd00::|fe80::)/; // Matches IPv6 private
-    const localhostIpv4Regex = /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/; // Matches 127.x.x.x
-    const localhostIpv6Regex = /^::1$/; // Matches ::1 (IPv6 localhost)
+const isPublicIp = (ip: string): boolean => {
+  const privateIpPatterns = [
+    /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,         // Matches 10.x.x.x
+    /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/, // Matches 172.16.x.x to 172.31.x.x
+    /^192\.168\.\d{1,3}\.\d{1,3}$/,            // Matches 192.168.x.x
+    /^169\.254\.\d{1,3}\.\d{1,3}$/,            // Matches 169.254.x.x (APIPA)
+    /^(fc00::|fd00::|fe80::)/,                 // Matches IPv6 private
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,        // Matches 127.x.x.x
+    /^::1$/                                    // Matches ::1 (IPv6 localhost)
+  ];
 
-    return !(
-      privateIp10Regex.test(ip) ||
-      privateIp172Regex.test(ip) ||
-      privateIp192Regex.test(ip) ||
-      apipaRegex.test(ip) ||
-      privateIpv6Regex.test(ip) ||
-      localhostIpv4Regex.test(ip) ||
-      localhostIpv6Regex.test(ip)
-    );
-  };
+  return !privateIpPatterns.some(pattern => pattern.test(ip));
+};
 
   const publicMacAddresses = new Set<string>();
 

--- a/src/steps/converters.ts
+++ b/src/steps/converters.ts
@@ -156,16 +156,6 @@ export function getMacAddresses(
   networkInterfaces: SentinelOneAgent['networkInterfaces'],
 ): string[] {
   const isPublicIp = (ip: string): boolean => {
-    const privateIpPatterns = [
-      /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, // Matches 10.x.x.x
-      /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/, // Matches 172.16.x.x to 172.31.x.x
-      /^192\.168\.\d{1,3}\.\d{1,3}$/, // Matches 192.168.x.x
-      /^169\.254\.\d{1,3}\.\d{1,3}$/, // Matches 169.254.x.x (APIPA)
-      /^(fc00::|fd00::|fe80::)/, // Matches IPv6 private
-      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, // Matches 127.x.x.x
-      /^::1$/, // Matches ::1 (IPv6 localhost)
-    ];
-
     return !privateIpPatterns.some((pattern) => pattern.test(ip));
   };
 
@@ -193,3 +183,13 @@ export function getMacAddresses(
 
   return [...publicMacAddresses];
 }
+
+const privateIpPatterns = [
+  /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, // Matches 10.x.x.x
+  /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/, // Matches 172.16.x.x to 172.31.x.x
+  /^192\.168\.\d{1,3}\.\d{1,3}$/, // Matches 192.168.x.x
+  /^169\.254\.\d{1,3}\.\d{1,3}$/, // Matches 169.254.x.x (APIPA)
+  /^(fc00::|fd00::|fe80::)/, // Matches IPv6 private
+  /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, // Matches 127.x.x.x
+  /^::1$/, // Matches ::1 (IPv6 localhost)
+];

--- a/src/steps/converters.ts
+++ b/src/steps/converters.ts
@@ -155,19 +155,19 @@ export function createAgentEntity(
 export function getMacAddresses(
   networkInterfaces: SentinelOneAgent['networkInterfaces'],
 ): string[] {
-const isPublicIp = (ip: string): boolean => {
-  const privateIpPatterns = [
-    /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,         // Matches 10.x.x.x
-    /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/, // Matches 172.16.x.x to 172.31.x.x
-    /^192\.168\.\d{1,3}\.\d{1,3}$/,            // Matches 192.168.x.x
-    /^169\.254\.\d{1,3}\.\d{1,3}$/,            // Matches 169.254.x.x (APIPA)
-    /^(fc00::|fd00::|fe80::)/,                 // Matches IPv6 private
-    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/,        // Matches 127.x.x.x
-    /^::1$/                                    // Matches ::1 (IPv6 localhost)
-  ];
+  const isPublicIp = (ip: string): boolean => {
+    const privateIpPatterns = [
+      /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, // Matches 10.x.x.x
+      /^172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}$/, // Matches 172.16.x.x to 172.31.x.x
+      /^192\.168\.\d{1,3}\.\d{1,3}$/, // Matches 192.168.x.x
+      /^169\.254\.\d{1,3}\.\d{1,3}$/, // Matches 169.254.x.x (APIPA)
+      /^(fc00::|fd00::|fe80::)/, // Matches IPv6 private
+      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, // Matches 127.x.x.x
+      /^::1$/, // Matches ::1 (IPv6 localhost)
+    ];
 
-  return !privateIpPatterns.some(pattern => pattern.test(ip));
-};
+    return !privateIpPatterns.some((pattern) => pattern.test(ip));
+  };
 
   const publicMacAddresses = new Set<string>();
 
@@ -176,16 +176,20 @@ const isPublicIp = (ip: string): boolean => {
     const hasPublicIp =
       (ni.inet?.length && ni.inet.some(isPublicIp)) ||
       (ni.inet6?.length && ni.inet6.some(isPublicIp));
-    if (hasPublicIp && ni.physical !== "00:00:00:00:00:00") {
+    if (hasPublicIp && ni.physical !== '00:00:00:00:00:00') {
       publicMacAddresses.add(ni.physical);
     }
 
     // When selecting macAddresses, prefer networkInterfaces with a gatewayIp as they are more likely to have
     // had their physical macAddress given to them by a central authority rather than being purely virtual.
-    if (ni.gatewayIp && ni.gatewayMacAddress && ni.gatewayMacAddress !== "00:00:00:00:00:00") {
+    if (
+      ni.gatewayIp &&
+      ni.gatewayMacAddress &&
+      ni.gatewayMacAddress !== '00:00:00:00:00:00'
+    ) {
       publicMacAddresses.add(ni.gatewayMacAddress);
     }
   });
 
-  return [...publicMacAddresses]
+  return [...publicMacAddresses];
 }


### PR DESCRIPTION
This new macAddress selection first checks the ipAddress of the network interface to ensure that there is at least one public ipAddress associated with that macAddress prior to selecting it. It also takes all gatewayMacAddresses as those are selected by a central authority and should be trusted.